### PR TITLE
[Feat] Editor-Plus 에서 사용되는 컴포넌트 추가하였습니당

### DIFF
--- a/GBZG.xcodeproj/project.pbxproj
+++ b/GBZG.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		163A0F9C2925261E00BFF0D2 /* EditorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163A0F9B2925261E00BFF0D2 /* EditorRow.swift */; };
+		163A0FA02925582700BFF0D2 /* TagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163A0F9F2925582700BFF0D2 /* TagButton.swift */; };
 		7AD990AB291A9C9E00553E2A /* GBZGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD990AA291A9C9E00553E2A /* GBZGApp.swift */; };
 		7AD990AD291A9C9E00553E2A /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD990AC291A9C9E00553E2A /* MainView.swift */; };
 		7AD990AF291A9CA000553E2A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AD990AE291A9CA000553E2A /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		163A0F9B2925261E00BFF0D2 /* EditorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorRow.swift; sourceTree = "<group>"; };
+		163A0F9F2925582700BFF0D2 /* TagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagButton.swift; sourceTree = "<group>"; };
 		7AD990A7291A9C9E00553E2A /* GBZG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GBZG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AD990AA291A9C9E00553E2A /* GBZGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBZGApp.swift; sourceTree = "<group>"; };
 		7AD990AC291A9C9E00553E2A /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 			children = (
 				7AD990BD291AA38900553E2A /* SampleComponent.swift */,
 				163A0F9B2925261E00BFF0D2 /* EditorRow.swift */,
+				163A0F9F2925582700BFF0D2 /* TagButton.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -208,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A09CBA74292296EA00D31F5F /* HomeView.swift in Sources */,
+				163A0FA02925582700BFF0D2 /* TagButton.swift in Sources */,
 				163A0F9C2925261E00BFF0D2 /* EditorRow.swift in Sources */,
 				7AD990C6291AA9A100553E2A /* Color+.swift in Sources */,
 				A09CBA76292296F400D31F5F /* WriteView.swift in Sources */,

--- a/GBZG.xcodeproj/project.pbxproj
+++ b/GBZG.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		163A0F9C2925261E00BFF0D2 /* EditorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163A0F9B2925261E00BFF0D2 /* EditorRow.swift */; };
 		7AD990AB291A9C9E00553E2A /* GBZGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD990AA291A9C9E00553E2A /* GBZGApp.swift */; };
 		7AD990AD291A9C9E00553E2A /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD990AC291A9C9E00553E2A /* MainView.swift */; };
 		7AD990AF291A9CA000553E2A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AD990AE291A9CA000553E2A /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		163A0F9B2925261E00BFF0D2 /* EditorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorRow.swift; sourceTree = "<group>"; };
 		7AD990A7291A9C9E00553E2A /* GBZG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GBZG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AD990AA291A9C9E00553E2A /* GBZGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBZGApp.swift; sourceTree = "<group>"; };
 		7AD990AC291A9C9E00553E2A /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				7AD990BD291AA38900553E2A /* SampleComponent.swift */,
+				163A0F9B2925261E00BFF0D2 /* EditorRow.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -205,6 +208,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A09CBA74292296EA00D31F5F /* HomeView.swift in Sources */,
+				163A0F9C2925261E00BFF0D2 /* EditorRow.swift in Sources */,
 				7AD990C6291AA9A100553E2A /* Color+.swift in Sources */,
 				A09CBA76292296F400D31F5F /* WriteView.swift in Sources */,
 				7AD990AD291A9C9E00553E2A /* MainView.swift in Sources */,

--- a/GBZG/View/Component/EditorRow.swift
+++ b/GBZG/View/Component/EditorRow.swift
@@ -14,28 +14,41 @@ struct EditorRow: View {
     
     var body: some View {
         HStack {
-            Image(systemName: "line.3.horizontal")
-                .font(.system(size: 20, weight: .medium))
-                .foregroundColor(.textField)
+            threeLineView
                 .padding(8)
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    Text(editorType.rawValue)
-                        .lineLimit(1)
-                        .font(.system(size: 17, weight: .light))
-                        .foregroundColor(.primary)
+                    titleLabelView
                     Spacer()
-                    Button {
-                        
-                    } label: {
-                        Image(systemName: "xmark.app")
-                            .font(.system(size: 20, weight: .medium))
-                            .foregroundColor(.textField)
-                    }
+                    xmarkButtonView
                 }
                 inputView(for: editorType)
             }
             .padding(8)
+        }
+    }
+}
+
+extension EditorRow {
+    private var threeLineView: some View {
+        Image(systemName: "line.3.horizontal")
+            .font(.system(size: 20, weight: .medium))
+            .foregroundColor(.textField)
+    }
+    
+    private var titleLabelView: some View {
+        Text(editorType.rawValue)
+            .font(.system(size: 17, weight: .light))
+            .foregroundColor(.primary)
+    }
+    
+    private var xmarkButtonView: some View {
+        Button {
+            
+        } label: {
+            Image(systemName: "xmark.app")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(.textField)
         }
     }
     
@@ -59,11 +72,11 @@ struct EditorRow: View {
     }
     
     private var overlayView: some View {
-        GeometryReader { geo in
+        GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 Rectangle()
                     .foregroundColor(.primaryPurple)
-                    .frame(width: CGFloat(rating) * geo.size.width / 5.0 )
+                    .frame(width: CGFloat(rating) * geometry.size.width / 5.0 )
             }
         }
         .allowsHitTesting(false)
@@ -101,76 +114,28 @@ struct EditorRow: View {
         case .isSuccess:
             return AnyView(
                 HStack(spacing: 8) {
-                    Button {
+                    TagButton(label: "탈출 성공") {
                         
-                    } label: {
-                        Text("탈출 성공")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
-                    Button {
+                    TagButton(label: "탈출 실패") {
                         
-                    } label: {
-                        Text("탈출 실패")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
                 }
             )
         case .grade:
             return AnyView(
                 HStack(spacing: 8) {
-                    Button {
+                    TagButton(label: "흙길") {
                         
-                    } label: {
-                        Text("흙길")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
-                    Button {
+                    TagButton(label: "풀길") {
                         
-                    } label: {
-                        Text("풀길")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
-                    Button {
+                    TagButton(label: "꽃길") {
                         
-                    } label: {
-                        Text("꽃길")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
-                    Button {
+                    TagButton(label: "인생 테마") {
                         
-                    } label: {
-                        Text("인생테마")
-                            .font(.system(size: 15, weight: .light))
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(Color.tagBase)
-                            .cornerRadius(12)
                     }
                 }
             )

--- a/GBZG/View/Component/EditorRow.swift
+++ b/GBZG/View/Component/EditorRow.swift
@@ -1,0 +1,205 @@
+//
+//  EditorRow.swift
+//  GBZG
+//
+//  Created by Wonhyuk Choi on 2022/11/16.
+//
+
+import SwiftUI
+
+struct EditorRow: View {
+    let editorType: EditorType
+    @State var inputValue: String = ""
+    @State var rating: Float = 2.5
+    
+    var body: some View {
+        HStack {
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(.textField)
+                .padding(8)
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text(editorType.rawValue)
+                        .lineLimit(1)
+                        .font(.system(size: 17, weight: .light))
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Button {
+                        
+                    } label: {
+                        Image(systemName: "xmark.app")
+                            .font(.system(size: 20, weight: .medium))
+                            .foregroundColor(.textField)
+                    }
+                }
+                inputView(for: editorType)
+            }
+            .padding(8)
+        }
+    }
+    
+    private var starsView: some View {
+        HStack(spacing: 8) {
+            ForEach(1..<6) { index in
+                Image("Star")
+                    .foregroundColor(.tagBase)
+                    .gesture(TapGesture(count: 2).onEnded {
+                        withAnimation(.easeInOut) {
+                            rating = Float(index)-0.5
+                        }
+                    })
+                    .simultaneousGesture(TapGesture().onEnded {
+                        withAnimation(.easeInOut) {
+                            rating = Float(index)
+                        }
+                    })
+            }
+        }
+    }
+    
+    private var overlayView: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .foregroundColor(.primaryPurple)
+                    .frame(width: CGFloat(rating) * geo.size.width / 5.0 )
+            }
+        }
+        .allowsHitTesting(false)
+    }
+    
+    private func inputView(for type: EditorType) -> some View {
+        switch type {
+        case .difficulty:
+            return AnyView(
+                starsView
+                    .overlay(overlayView.mask(starsView))
+            )
+        case .hintsUsed:
+            return AnyView(
+                HStack {
+                    TextField("", text: $inputValue)
+                        .keyboardType(.decimalPad)
+                        .overlay(
+                            GeometryReader { geo in
+                                Path { path in
+                                    path.move(to: CGPoint(x: 0, y: geo.size.height))
+                                    path.addLine(to: CGPoint(x: geo.size.width, y: geo.size.height))
+                                }
+                                .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 1])) // adjust to your liking
+                                .foregroundColor(.secondary)
+                            }
+                        )
+                        .frame(minWidth: 30)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Text("개")
+                        .font(.system(size: 15, weight: .light))
+                        .foregroundColor(.secondary)
+                }
+            )
+        case .isSuccess:
+            return AnyView(
+                HStack(spacing: 8) {
+                    Button {
+                        
+                    } label: {
+                        Text("탈출 성공")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                    Button {
+                        
+                    } label: {
+                        Text("탈출 실패")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                }
+            )
+        case .grade:
+            return AnyView(
+                HStack(spacing: 8) {
+                    Button {
+                        
+                    } label: {
+                        Text("흙길")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                    Button {
+                        
+                    } label: {
+                        Text("풀길")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                    Button {
+                        
+                    } label: {
+                        Text("꽃길")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                    Button {
+                        
+                    } label: {
+                        Text("인생테마")
+                            .font(.system(size: 15, weight: .light))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color.tagBase)
+                            .cornerRadius(12)
+                    }
+                }
+            )
+        case .record:
+            return AnyView(
+                TextField("기록하고 싶은 내용들을 작성해주세요", text: $inputValue)
+                    .font(.system(size: 15, weight: .regular))
+            )
+        }
+    }
+}
+
+enum EditorType: String {
+    case difficulty = "체감 난이도"
+    case hintsUsed = "사용 힌트 수"
+    case isSuccess = "테마 성공 여부"
+    case grade = "평점"
+    case record = "기록"
+}
+
+//struct EditorRow_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack {
+//            EditorRow(editorType: .difficulty)
+//            EditorRow(editorType: .hintsUsed)
+//            EditorRow(editorType: .isSuccess)
+//            EditorRow(editorType: .grade)
+//            EditorRow(editorType: .record)
+//        }
+//        .previewLayout(.sizeThatFits)
+//    }
+//}

--- a/GBZG/View/Component/TagButton.swift
+++ b/GBZG/View/Component/TagButton.swift
@@ -1,0 +1,28 @@
+//
+//  TagButton.swift
+//  GBZG
+//
+//  Created by Wonhyuk Choi on 2022/11/17.
+//
+
+import SwiftUI
+
+struct TagButton: View {
+    let label: String
+    let backgroudColor: Color = .tagBase
+    let action: () -> Void
+    
+    var body: some View {
+        Button {
+            
+        } label: {
+            Text(label)
+                .font(.system(size: 15, weight: .light))
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(backgroudColor)
+                .cornerRadius(12)
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

https://user-images.githubusercontent.com/56063805/202240492-af11aa7d-f311-4f46-8a34-a728c5e97ea5.mov

- [x] 에디터 플러스 기본적인 셀 작업
- [x] 5가지 타입에 따라 입력 뷰 변화
- [ ] 로직 추가

## 리뷰 포인트
- 로직은 없이 오직 뷰만 추가하였습니다.
- 별 점의 경우 더블 탭으로 눌러야 .5 점을 줄수 있게 하였습니다.

## 질문
- 마스킹을 해서 별점에 색상을 주었는데 .5 같은 경우에는 가로 사이즈에서 계산하게 되면 2.5 말고는 불편한 위치에 색상이 채워집니다. 이 부분을 어떻게 해결하면 좋을지 논의가 필요합니다.

## 다음 진행할 작업
- 버튼 로직

## 참고한 자료
- https://www.youtube.com/watch?v=pxx1ueCbnls