### PR TITLE
[Feat]TemplateCreationView UI 구성

### DIFF
--- a/GBZG.xcodeproj/project.pbxproj
+++ b/GBZG.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		7AD990C6291AA9A100553E2A /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD990C5291AA9A100553E2A /* Color+.swift */; };
 		7ADA261F296DC18200117A12 /* BasicInfoContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADA261E296DC18200117A12 /* BasicInfoContent.swift */; };
 		A04F1316296F08FF0004F3CC /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04F1315296F08FF0004F3CC /* Font+.swift */; };
+		A069331529EC964E001DF304 /* TemplateCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A069331429EC964E001DF304 /* TemplateCreationView.swift */; };
 		A09CBA70292295E700D31F5F /* GBZGTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09CBA6F292295E700D31F5F /* GBZGTabView.swift */; };
 		A09CBA722922962400D31F5F /* GBZGTabRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09CBA712922962400D31F5F /* GBZGTabRouter.swift */; };
 		A09CBA74292296EA00D31F5F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09CBA73292296EA00D31F5F /* HomeView.swift */; };
@@ -69,6 +70,7 @@
 		7AD990C5291AA9A100553E2A /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		7ADA261E296DC18200117A12 /* BasicInfoContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicInfoContent.swift; sourceTree = "<group>"; };
 		A04F1315296F08FF0004F3CC /* Font+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
+		A069331429EC964E001DF304 /* TemplateCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCreationView.swift; sourceTree = "<group>"; };
 		A09CBA6F292295E700D31F5F /* GBZGTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBZGTabView.swift; sourceTree = "<group>"; };
 		A09CBA712922962400D31F5F /* GBZGTabRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBZGTabRouter.swift; sourceTree = "<group>"; };
 		A09CBA73292296EA00D31F5F /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				A09CBA77292296FE00D31F5F /* TemplateView.swift */,
+				A069331429EC964E001DF304 /* TemplateCreationView.swift */,
 			);
 			path = Template;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 				C172324329AF52A8005EFE85 /* RankingView.swift in Sources */,
 				C172324729AF8ECD005EFE85 /* RankingItem.swift in Sources */,
 				A0F693B12977B720005B7521 /* ThemeDetailView.swift in Sources */,
+				A069331529EC964E001DF304 /* TemplateCreationView.swift in Sources */,
 				A09CBA78292296FE00D31F5F /* TemplateView.swift in Sources */,
 				25B96F912976D3B500987134 /* SearchBar.swift in Sources */,
 				7AD990AB291A9C9E00553E2A /* GBZGApp.swift in Sources */,

--- a/GBZG/View/Template/TemplateCreationView.swift
+++ b/GBZG/View/Template/TemplateCreationView.swift
@@ -82,7 +82,7 @@ extension TemplateCreationView {
             .frame(minHeight: 20)
             .padding(.bottom, 4)
             Rectangle()
-                .frame(height: 0.5)
+                .frame(height: 1.0)
                 .foregroundColor(templateName == "" ? .textTertiary : focusField == .templateName ? .purple030 : .textSecondary)
         }
         .padding(.bottom, 36)

--- a/GBZG/View/Template/TemplateCreationView.swift
+++ b/GBZG/View/Template/TemplateCreationView.swift
@@ -13,10 +13,15 @@ struct Component: Hashable {
     var listNumber: Int = 0
 }
 
+enum Field: Hashable {
+    case templateName
+}
+
 struct TemplateCreationView: View {
     
-    @State var text = ""
-    @State var allComponents: [Component] = [
+    @State private var templateName = ""
+    @FocusState private var focusField: Field?
+    @State private var allComponents: [Component] = [
         Component(name: "대충"),
         Component(name: "템플릿의"),
         Component(name: "구성"),
@@ -61,14 +66,15 @@ extension TemplateCreationView {
     var TemplateNameEditContainer: some View {
         VStack {
             HStack {
-                TextField("", text: $text, prompt: Text("템플릿 이름을 입력해주세요."))
+                TextField("", text: $templateName, prompt: Text("템플릿 이름을 입력해주세요."))
+                    .focused($focusField, equals: .templateName)
                     .foregroundColor(.textSecondary)
                 Spacer()
-                if text != "" {
+                if templateName != "" && focusField == .templateName {
                     Image(systemName: "clear.fill")
                         .foregroundColor(.textSecondary)
                         .onTapGesture {
-                            text = ""
+                            templateName = ""
                         }
                 }
             }
@@ -76,8 +82,8 @@ extension TemplateCreationView {
             .frame(minHeight: 20)
             .padding(.bottom, 4)
             Rectangle()
-                .frame(height: 0.8)
-                .foregroundColor(text == "" ? .textPrimary : .purple030)
+                .frame(height: 0.5)
+                .foregroundColor(templateName == "" ? .textTertiary : focusField == .templateName ? .purple030 : .textSecondary)
         }
         .padding(.bottom, 36)
     }

--- a/GBZG/View/Template/TemplateCreationView.swift
+++ b/GBZG/View/Template/TemplateCreationView.swift
@@ -37,6 +37,14 @@ struct TemplateCreationView: View {
             Spacer()
         }
         .padding(16)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing, content: {
+                Button(action: {
+                }, label: {
+                    Text("등록")
+                })
+            })
+        }
     }
 }
 

--- a/GBZG/View/Template/TemplateCreationView.swift
+++ b/GBZG/View/Template/TemplateCreationView.swift
@@ -7,12 +7,33 @@
 
 import SwiftUI
 
+struct Component: Hashable {
+    var name: String
+    var isChecked: Bool = false
+    var listNumber: Int = 0
+}
+
 struct TemplateCreationView: View {
+    
     @State var text = ""
+    @State var allComponents: [Component] = [
+        Component(name: "대충"),
+        Component(name: "템플릿의"),
+        Component(name: "구성"),
+        Component(name: "요소"),
+        Component(name: "이름입니다"),
+        Component(name: "하하"),
+        Component(name: "호호"),
+        Component(name: "쿄쿄"),
+        Component(name: "후후")
+    ]
+    
     var body: some View {
         VStack {
             TemplateCreationViewHeader
             TemplateNameEditContainer
+            TemplateComponentsEditContainer
+            AddOptionButton
             Spacer()
         }
         .padding(16)
@@ -26,7 +47,7 @@ extension TemplateCreationView {
                 .gbzgLargeTitle()
             Spacer()
         }
-        .padding(.bottom, 12)
+        .padding(.bottom, 16)
     }
     
     var TemplateNameEditContainer: some View {
@@ -50,23 +71,57 @@ extension TemplateCreationView {
                 .frame(height: 0.8)
                 .foregroundColor(text == "" ? .textPrimary : .purple030)
         }
+        .padding(.bottom, 36)
     }
     
     var TemplateComponentsEditContainer: some View {
-        Text("hi")
-        // TemplateComponentItem:
-        /*
-        ScrollView(showsIndicators: false) {
-            ForEach(items, id: \.self) { item in
-                NavigationLink(destination: Text("\(item)")) {
-                    ItemCell(title: "item.title", components: ["item.component1", "item.component2"])
-                        .padding(.bottom, 12)
-                }
+        VStack {
+            HStack {
+                Text("구성 요소")
+                    .gbzgSubtitle()
+                Spacer()
+            }
+            .padding(.bottom, 16)
+            ForEach($allComponents, id: \.self) { $component in
+                TemplateComponentsItem($component)
             }
         }
-         */
     }
     
+    func TemplateComponentsItem(_ item: Binding<Component>) -> some View {
+        HStack {
+            Image(systemName: item.isChecked.wrappedValue ? "\(item.listNumber.wrappedValue).square.fill" : "square")
+                .foregroundColor(item.isChecked.wrappedValue ? .purple030 : .black)
+                .onTapGesture {
+                    item.isChecked.wrappedValue.toggle()
+                    if item.isChecked.wrappedValue {
+                        item.listNumber.wrappedValue = allComponents.filter({ $0.isChecked }).count
+                    } else {
+                        allComponents.enumerated().forEach { (index, component) in
+                            if component.listNumber > item.listNumber.wrappedValue {
+                                allComponents[index].listNumber -= 1
+                            }
+                        }
+                    }
+                }
+            Text(item.name.wrappedValue)
+            Spacer()
+        }
+        .gbzgBody1()
+        .padding(.bottom, 16)
+    }
+    
+    var AddOptionButton: some View {
+        Button(action: {
+        }, label: {
+            HStack {
+                Image(systemName: "plus")
+                Text("옵션 추가")
+                Spacer()
+            }
+            .foregroundColor(.textPrimary)
+        })
+    }
 }
 
 struct TemplateCreationView_Previews: PreviewProvider {

--- a/GBZG/View/Template/TemplateCreationView.swift
+++ b/GBZG/View/Template/TemplateCreationView.swift
@@ -1,0 +1,76 @@
+//
+//  TemplateCreationView.swift
+//  GBZG
+//
+//  Created by KiWoong Hong on 2023/04/17.
+//
+
+import SwiftUI
+
+struct TemplateCreationView: View {
+    @State var text = ""
+    var body: some View {
+        VStack {
+            TemplateCreationViewHeader
+            TemplateNameEditContainer
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+extension TemplateCreationView {
+    var TemplateCreationViewHeader: some View {
+        HStack {
+            Text("템플릿 만들기")
+                .gbzgLargeTitle()
+            Spacer()
+        }
+        .padding(.bottom, 12)
+    }
+    
+    var TemplateNameEditContainer: some View {
+        VStack {
+            HStack {
+                TextField("", text: $text, prompt: Text("템플릿 이름을 입력해주세요."))
+                    .foregroundColor(.textSecondary)
+                Spacer()
+                if text != "" {
+                    Image(systemName: "clear.fill")
+                        .foregroundColor(.textSecondary)
+                        .onTapGesture {
+                            text = ""
+                        }
+                }
+            }
+            .foregroundColor(.purple030)
+            .frame(minHeight: 20)
+            .padding(.bottom, 4)
+            Rectangle()
+                .frame(height: 0.8)
+                .foregroundColor(text == "" ? .textPrimary : .purple030)
+        }
+    }
+    
+    var TemplateComponentsEditContainer: some View {
+        Text("hi")
+        // TemplateComponentItem:
+        /*
+        ScrollView(showsIndicators: false) {
+            ForEach(items, id: \.self) { item in
+                NavigationLink(destination: Text("\(item)")) {
+                    ItemCell(title: "item.title", components: ["item.component1", "item.component2"])
+                        .padding(.bottom, 12)
+                }
+            }
+        }
+         */
+    }
+    
+}
+
+struct TemplateCreationView_Previews: PreviewProvider {
+    static var previews: some View {
+        TemplateCreationView()
+    }
+}

--- a/GBZG/View/Template/TemplateView.swift
+++ b/GBZG/View/Template/TemplateView.swift
@@ -39,7 +39,7 @@ private extension TemplateView {
             Text("내 템플릿")
                 .gbzgLargeTitle()
             Spacer()
-            NavigationLink(destination: Text("good")) {
+            NavigationLink(destination: TemplateCreationView()) {
                 Image(systemName: "plus")
                     .tint(.textField)
             }


### PR DESCRIPTION
## 작업 내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- #24  TemplateCreationView UI 작업

https://user-images.githubusercontent.com/91725382/232398217-94937532-0263-4c14-b38c-512300a04231.mp4


## 리뷰 포인트
- 코드가 보기에 좀 지저분하게 보이겠지만, 맞습니다.
- 텍스트필드는 포커스돼있는지, 텍스트가 빈칸인지에 따라 밑줄 색이 변하도록 하였습니다. 
- 체크박스 넘버링은 템플릿 요소에서 체크된 숫자를 세서 숫자변경을 해줬고, 중간 숫자를 해제할 경우, 알잘딱 숫자가 바뀌도록 하였습니다.

## 질문
<!-- PR 과정에서 생긴 질문을 적어주세요. -->
- 진지하게 이 부분 UI 수정하는거 어떤지 건의해봅니다~ 이유는 4가지 정도..
- 1. 현재 옵션 추가 버튼이 +가 있긴하지만 버튼으로 잘 인식이 안됩니다.
- 2. 저 넘버링 체크박스로 할 경우, 로직을 넣어야되서 코드가 개인적으로 좀 지저분해 보입니다.
- 3. 유저 입장에서 자기가 사용하지도않을 템플릿 구성 요소가 나와있는 것 보다 자기가 추가한 템플릿 구성만 보는게 더 나을 것 같다는 생각입니다.
- 4. 자기가 추가한 템플릿 요소를 삭제할 수가 없어서 체크박스가 아니라 순서 변경과 삭제를 링크에서처럼 구성하고 옵션 추가 버튼을 넣는 건 어떨까요?? 
- https://koenig-media.raywenderlich.com/uploads/2021/05/005_OnMove.gif?__hstc=149040233.0c9a7f439f1667186acf67ddcd1ad981.1678088996126.1680987819919.1681694682715.14&__hssc=149040233.1.1681694682715&__hsfp=3752540723
- 

